### PR TITLE
[감하영] Dark mode 및 차트 Theme, Monochrome 색상 적용 기능 구현

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -15,7 +15,7 @@ module.exports = {
     'no-unused-vars': 'warn',
     quotes: ['warn', 'single'],
     semi: ['error', 'always'],
-    indent: ['error', 2],
+    indent: 'off',
     'prettier/prettier': [
       'error',
       {

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -6,6 +6,13 @@
       <input class="monochrome-color-picker-input" type="color" id="monochrome" @change="setMonochromeColor" />
     </div>
 
+    <div class="dark-mode-toggle-button">
+      <label class="dark-mode-toggle-button-label">
+        Dark Mode
+        <input class="dark-mode-toggle-button-input" type="checkbox" @change="toggleDarkMode" />
+      </label>
+    </div>
+
     <!-- TODO: Theme swatches 서비스단으로 이동 -->
     <ul class="theme-swatches" v-for="(swatch, index) in palette" :key="index">
       <li class="theme-swatches-item" v-for="theme in swatch" :key="theme.name" @click="switchTheme(theme.name)">
@@ -26,6 +33,7 @@
     <button class="editBtn" @click="layoutEditable = !layoutEditable">Edit</button>
     <vuetiful-board
       :theme="theme"
+      :dark-mode="darkMode"
       :col-num="colNum"
       :row-height="rowHeight"
       :layout-editable="layoutEditable"
@@ -492,6 +500,7 @@ export default {
   data() {
     return {
       theme: 'classic',
+      darkMode: false,
       layoutEditable: true,
       colNum: 12,
       rowHeight: 30,
@@ -507,7 +516,10 @@ export default {
     },
     setMonochromeColor(event) {
       this.theme = event.target.value;
-    }
+    },
+    toggleDarkMode() {
+      this.darkMode = !this.darkMode;
+    },
   },
 };
 </script>

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -142,7 +142,7 @@
             }
           },
           gridInfo: {
-            x: 6, y: 0, w: 6, h: 12, i: '1', static: false
+            x: 6, y: 0, w: 6, h: 15, i: '1', static: false
           },
         },
         {
@@ -270,7 +270,7 @@
             }
           },
           gridInfo: {
-            x: 0, y: 10, w: 6, h: 10, i: '2', static: false
+            x: 0, y: 10, w: 6, h: 12, i: '2', static: false
           },
         },
         {
@@ -325,7 +325,7 @@
             }
           },
           gridInfo: {
-            x: 6, y: 10, w: 6, h: 10, i: '3', static: false
+            x: 6, y: 10, w: 6, h: 12, i: '3', static: false
           },
         },
         {
@@ -388,7 +388,7 @@
             }
           },
           gridInfo: {
-            x: 0, y: 20, w: 6, h: 10, i: '4', static: false
+            x: 0, y: 20, w: 6, h: 12, i: '4', static: false
           },
         },
         {
@@ -474,7 +474,7 @@
             },
           },
           gridInfo: {
-            x: 6, y: 20, w: 6, h: 10, i: '5', static: false
+            x: 6, y: 20, w: 6, h: 12, i: '5', static: false
           }
         }
       ]"

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -9,7 +9,7 @@
     <div class="dark-mode-toggle-button">
       <label class="dark-mode-toggle-button-label">
         Dark Mode
-        <input class="dark-mode-toggle-button-input" type="checkbox" @change="toggleDarkMode" />
+        <input class="dark-mode-toggle-button-input" type="checkbox" v-model="darkMode" />
       </label>
     </div>
 
@@ -516,9 +516,6 @@ export default {
     },
     setMonochromeColor(event) {
       this.theme = event.target.value;
-    },
-    toggleDarkMode() {
-      this.darkMode = !this.darkMode;
     },
   },
 };

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -3,7 +3,7 @@
     <!-- TODO: Monochrome color picker 서비스단으로 이동 -->
     <div class="monochrome-color-picker">
       <label class="monochrome-color-picker-label" for="monochrome">Monochrome</label>
-      <input class="monochrome-color-picker-input" type="color" id="monochrome" name="monochrome" @change="setMonochromeColor" />
+      <input class="monochrome-color-picker-input" type="color" id="monochrome" @change="setMonochromeColor" />
     </div>
 
     <!-- TODO: Theme swatches 서비스단으로 이동 -->

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -7,63 +7,11 @@
     </div>
 
     <!-- TODO: Theme swatches 서비스단으로 이동 -->
-    <ul class="theme-swatches">
-      <li class="theme-swatches-item" @click="switchTheme">
-        <label class="theme-swatches-label" for="classic">
-          <input class="theme-swatches-checkbox" type="checkbox" id="classic" />
-          <span class="theme-swatches-name">Classic</span>
-          <span class="theme-swatches-palette">
-            <span class="hue primary"></span>
-            <span class="hue secondary"></span>
-            <span class="hue third"></span>
-            <span class="hue fourth"></span>
-            <span class="hue fifth"></span>
-          </span>
-        </label>
-      </li>
-      <li class="theme-swatches-item" @click="switchTheme">
-        <label class="theme-swatches-label" for="rainbow">
-          <input class="theme-swatches-checkbox" type="checkbox" id="rainbow" />
-          <span class="theme-swatches-name">Rainbow</span>
-          <span class="theme-swatches-palette">
-            <span class="hue primary"></span>
-            <span class="hue secondary"></span>
-            <span class="hue third"></span>
-            <span class="hue fourth"></span>
-            <span class="hue fifth"></span>
-          </span>
-        </label>
-      </li>
-      <li class="theme-swatches-item" @click="switchTheme">
-        <label class="theme-swatches-label" for="vintage">
-          <input class="theme-swatches-checkbox" type="checkbox" id="vintage" />
-          <span class="theme-swatches-name">Vintage</span>
-          <span class="theme-swatches-palette">
-            <span class="hue primary"></span>
-            <span class="hue secondary"></span>
-            <span class="hue third"></span>
-            <span class="hue fourth"></span>
-            <span class="hue fifth"></span>
-          </span>
-        </label>
-      </li>
-      <li class="theme-swatches-item" @click="switchTheme">
-        <label class="theme-swatches-label" for="retro">
-          <input class="theme-swatches-checkbox" type="checkbox" id="retro" />
-          <span class="theme-swatches-name">Retro</span>
-          <span class="theme-swatches-palette">
-            <span class="hue primary"></span>
-            <span class="hue secondary"></span>
-            <span class="hue third"></span>
-            <span class="hue fourth"></span>
-            <span class="hue fifth"></span>
-          </span>
-        </label>
-      </li>
-      <li class="theme-swatches-item" @click="switchTheme">
-        <label class="theme-swatches-label" for="green">
-          <input class="theme-swatches-checkbox" type="checkbox" id="green" />
-          <span class="theme-swatches-name">Green</span>
+    <ul class="theme-swatches" v-for="(swatch, index) in palette" :key="index">
+      <li class="theme-swatches-item" v-for="theme in swatch" :key="theme.name" @click="switchTheme(theme.name)">
+        <label class="theme-swatches-label" :for="theme.name">
+          <input class="theme-swatches-checkbox" type="checkbox" :id="theme.name" />
+          <span class="theme-swatches-name">{{ theme.name }}</span>
           <span class="theme-swatches-palette">
             <span class="hue primary"></span>
             <span class="hue secondary"></span>
@@ -536,6 +484,7 @@
 
 <script>
 import VuetifulBoard from '../../src/components/VuetifulBoard.vue';
+import palette from '../../src/assets/palette.json';
 
 export default {
   components: { VuetifulBoard },
@@ -543,16 +492,19 @@ export default {
   data() {
     return {
       // TODO: Theme swatches에서 테마를 클릭하면 해당 테마의 이름을 가져와서 theme data에 바인딩
-      theme: 'rainbow',
+      theme: 'classic',
       layoutEditable: true,
       colNum: 12,
-      rowHeight: 30
+      rowHeight: 30,
+      palette: {
+        type: Array,
+        palette,
+      },
     }
   },
   methods: {
-    switchTheme() {
-      // TODO: Theme swatches를 클릭하면 해당 테마의 이름을 가져와서 theme data에 바인딩
-      this.theme = 'hoge';
+    switchTheme(themeName) {
+      this.theme = themeName;
     },
     setMonochromeColor(event) {
       this.theme = event.target.value;

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -2,7 +2,7 @@
   <div id="app">
     <!-- TODO: Monochrome color picker 서비스단으로 이동 -->
     <div class="monochrome-color-picker">
-      <label clas="monochrome-color-picker-label" for="monochrome">Monochrome</label>
+      <label class="monochrome-color-picker-label" for="monochrome">Monochrome</label>
       <input class="monochrome-color-picker-input" type="color" id="monochrome" name="monochrome" @change="setMonochromeColor" />
     </div>
 

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -556,6 +556,7 @@ export default {
 
   .theme-swatches-name {
     display: block;
+    color: #232323;
     font-size: 14px;
   }
 

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -491,7 +491,6 @@ export default {
   name: 'App',
   data() {
     return {
-      // TODO: Theme swatches에서 테마를 클릭하면 해당 테마의 이름을 가져와서 theme data에 바인딩
       theme: 'classic',
       layoutEditable: true,
       colNum: 12,

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -597,9 +597,9 @@ export default {
 
 .editBtn {
   padding: 7px;
-  border: 1px solid white;
+  border: 1px solid #fff;
   border-radius: 5px;
-  background: white;
+  background: #fff;
   cursor: pointer;
 }
 </style>

--- a/dev/src/App.vue
+++ b/dev/src/App.vue
@@ -1,5 +1,11 @@
 <template>
   <div id="app">
+    <!-- TODO: Monochrome color picker 서비스단으로 이동 -->
+    <div class="monochrome-color-picker">
+      <label clas="monochrome-color-picker-label" for="monochrome">Monochrome</label>
+      <input class="monochrome-color-picker-input" type="color" id="monochrome" name="monochrome" @change="setMonochromeColor" />
+    </div>
+
     <!-- TODO: Theme swatches 서비스단으로 이동 -->
     <ul class="theme-swatches">
       <li class="theme-swatches-item" @click="switchTheme">
@@ -548,6 +554,9 @@ export default {
       // TODO: Theme swatches를 클릭하면 해당 테마의 이름을 가져와서 theme data에 바인딩
       this.theme = 'hoge';
     },
+    setMonochromeColor(event) {
+      this.theme = event.target.value;
+    }
   },
 };
 </script>

--- a/dev/vue.config.js
+++ b/dev/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  devServer: {
+    host: 'localhost',
+  },
+};

--- a/docs/.vuepress/components/VuetifulBoardPlayground.vue
+++ b/docs/.vuepress/components/VuetifulBoardPlayground.vue
@@ -6,6 +6,13 @@
       <input class="monochrome-color-picker-input" type="color" id="monochrome" @change="setMonochromeColor" />
     </div>
 
+    <div class="dark-mode-toggle-button">
+      <label class="dark-mode-toggle-button-label">
+        Dark Mode
+        <input class="dark-mode-toggle-button-input" type="checkbox" @change="toggleDarkMode" />
+      </label>
+    </div>
+
     <!-- TODO: Theme swatches 서비스단으로 이동 -->
     <ul class="theme-swatches" v-for="(swatch, index) in palette" :key="index">
       <li class="theme-swatches-item" v-for="theme in swatch" :key="theme.name" @click="switchTheme(theme.name)">
@@ -26,6 +33,7 @@
     <button class="editBtn" @click="layoutEditable = !layoutEditable">Edit</button>
     <vuetiful-board
       :theme="theme"
+      :dark-mode="darkMode"
       :col-num="colNum"
       :row-height="rowHeight"
       :layout-editable="layoutEditable"
@@ -492,6 +500,7 @@ export default {
   data() {
     return {
       theme: 'classic',
+      darkMode: false,
       layoutEditable: true,
       colNum: 12,
       rowHeight: 30,
@@ -507,7 +516,10 @@ export default {
     },
     setMonochromeColor(event) {
       this.theme = event.target.value;
-    }
+    },
+    toggleDarkMode() {
+      this.darkMode = !this.darkMode;
+    },
   },
 };
 </script>

--- a/docs/.vuepress/components/VuetifulBoardPlayground.vue
+++ b/docs/.vuepress/components/VuetifulBoardPlayground.vue
@@ -9,7 +9,7 @@
     <div class="dark-mode-toggle-button">
       <label class="dark-mode-toggle-button-label">
         Dark Mode
-        <input class="dark-mode-toggle-button-input" type="checkbox" @change="toggleDarkMode" />
+        <input class="dark-mode-toggle-button-input" type="checkbox" v-model="darkMode" />
       </label>
     </div>
 
@@ -516,9 +516,6 @@ export default {
     },
     setMonochromeColor(event) {
       this.theme = event.target.value;
-    },
-    toggleDarkMode() {
-      this.darkMode = !this.darkMode;
     },
   },
 };

--- a/docs/.vuepress/components/VuetifulBoardPlayground.vue
+++ b/docs/.vuepress/components/VuetifulBoardPlayground.vue
@@ -7,63 +7,11 @@
     </div>
 
     <!-- TODO: Theme swatches 서비스단으로 이동 -->
-    <ul class="theme-swatches">
-      <li class="theme-swatches-item" @click="switchTheme">
-        <label class="theme-swatches-label" for="classic">
-          <input class="theme-swatches-checkbox" type="checkbox" id="classic" />
-          <span class="theme-swatches-name">Classic</span>
-          <span class="theme-swatches-palette">
-            <span class="hue primary"></span>
-            <span class="hue secondary"></span>
-            <span class="hue third"></span>
-            <span class="hue fourth"></span>
-            <span class="hue fifth"></span>
-          </span>
-        </label>
-      </li>
-      <li class="theme-swatches-item" @click="switchTheme">
-        <label class="theme-swatches-label" for="rainbow">
-          <input class="theme-swatches-checkbox" type="checkbox" id="rainbow" />
-          <span class="theme-swatches-name">Rainbow</span>
-          <span class="theme-swatches-palette">
-            <span class="hue primary"></span>
-            <span class="hue secondary"></span>
-            <span class="hue third"></span>
-            <span class="hue fourth"></span>
-            <span class="hue fifth"></span>
-          </span>
-        </label>
-      </li>
-      <li class="theme-swatches-item" @click="switchTheme">
-        <label class="theme-swatches-label" for="vintage">
-          <input class="theme-swatches-checkbox" type="checkbox" id="vintage" />
-          <span class="theme-swatches-name">Vintage</span>
-          <span class="theme-swatches-palette">
-            <span class="hue primary"></span>
-            <span class="hue secondary"></span>
-            <span class="hue third"></span>
-            <span class="hue fourth"></span>
-            <span class="hue fifth"></span>
-          </span>
-        </label>
-      </li>
-      <li class="theme-swatches-item" @click="switchTheme">
-        <label class="theme-swatches-label" for="retro">
-          <input class="theme-swatches-checkbox" type="checkbox" id="retro" />
-          <span class="theme-swatches-name">Retro</span>
-          <span class="theme-swatches-palette">
-            <span class="hue primary"></span>
-            <span class="hue secondary"></span>
-            <span class="hue third"></span>
-            <span class="hue fourth"></span>
-            <span class="hue fifth"></span>
-          </span>
-        </label>
-      </li>
-      <li class="theme-swatches-item" @click="switchTheme">
-        <label class="theme-swatches-label" for="green">
-          <input class="theme-swatches-checkbox" type="checkbox" id="green" />
-          <span class="theme-swatches-name">Green</span>
+    <ul class="theme-swatches" v-for="(swatch, index) in palette" :key="index">
+      <li class="theme-swatches-item" v-for="theme in swatch" :key="theme.name" @click="switchTheme(theme.name)">
+        <label class="theme-swatches-label" :for="theme.name">
+          <input class="theme-swatches-checkbox" type="checkbox" :id="theme.name" />
+          <span class="theme-swatches-name">{{ theme.name }}</span>
           <span class="theme-swatches-palette">
             <span class="hue primary"></span>
             <span class="hue secondary"></span>
@@ -194,7 +142,7 @@
             }
           },
           gridInfo: {
-            x: 6, y: 0, w: 6, h: 12, i: '1', static: false
+            x: 6, y: 0, w: 6, h: 15, i: '1', static: false
           },
         },
         {
@@ -322,7 +270,7 @@
             }
           },
           gridInfo: {
-            x: 0, y: 10, w: 6, h: 10, i: '2', static: false
+            x: 0, y: 10, w: 6, h: 12, i: '2', static: false
           },
         },
         {
@@ -377,7 +325,7 @@
             }
           },
           gridInfo: {
-            x: 6, y: 10, w: 6, h: 10, i: '3', static: false
+            x: 6, y: 10, w: 6, h: 12, i: '3', static: false
           },
         },
         {
@@ -440,7 +388,7 @@
             }
           },
           gridInfo: {
-            x: 0, y: 20, w: 6, h: 10, i: '4', static: false
+            x: 0, y: 20, w: 6, h: 12, i: '4', static: false
           },
         },
         {
@@ -526,7 +474,7 @@
             },
           },
           gridInfo: {
-            x: 6, y: 20, w: 6, h: 10, i: '5', static: false
+            x: 6, y: 20, w: 6, h: 12, i: '5', static: false
           }
         }
       ]"
@@ -536,6 +484,7 @@
 
 <script>
 import VuetifulBoard from '../../../src/components/VuetifulBoard.vue';
+import palette from '../../../src/assets/palette.json';
 
 export default {
   components: { VuetifulBoard },
@@ -543,16 +492,19 @@ export default {
   data() {
     return {
       // TODO: Theme swatches에서 테마를 클릭하면 해당 테마의 이름을 가져와서 theme data에 바인딩
-      theme: 'rainbow',
+      theme: 'classic',
       layoutEditable: true,
       colNum: 12,
-      rowHeight: 30
+      rowHeight: 30,
+      palette: {
+        type: Array,
+        palette,
+      },
     }
   },
   methods: {
-    switchTheme() {
-      // TODO: Theme swatches를 클릭하면 해당 테마의 이름을 가져와서 theme data에 바인딩
-      this.theme = 'hoge';
+    switchTheme(themeName) {
+      this.theme = themeName;
     },
     setMonochromeColor(event) {
       this.theme = event.target.value;

--- a/docs/.vuepress/components/VuetifulBoardPlayground.vue
+++ b/docs/.vuepress/components/VuetifulBoardPlayground.vue
@@ -3,7 +3,7 @@
     <!-- TODO: Monochrome color picker 서비스단으로 이동 -->
     <div class="monochrome-color-picker">
       <label class="monochrome-color-picker-label" for="monochrome">Monochrome</label>
-      <input class="monochrome-color-picker-input" type="color" id="monochrome" name="monochrome" @change="setMonochromeColor" />
+      <input class="monochrome-color-picker-input" type="color" id="monochrome" @change="setMonochromeColor" />
     </div>
 
     <!-- TODO: Theme swatches 서비스단으로 이동 -->

--- a/docs/.vuepress/components/VuetifulBoardPlayground.vue
+++ b/docs/.vuepress/components/VuetifulBoardPlayground.vue
@@ -2,7 +2,7 @@
   <div id="app">
     <!-- TODO: Monochrome color picker 서비스단으로 이동 -->
     <div class="monochrome-color-picker">
-      <label clas="monochrome-color-picker-label" for="monochrome">Monochrome</label>
+      <label class="monochrome-color-picker-label" for="monochrome">Monochrome</label>
       <input class="monochrome-color-picker-input" type="color" id="monochrome" name="monochrome" @change="setMonochromeColor" />
     </div>
 

--- a/docs/.vuepress/components/VuetifulBoardPlayground.vue
+++ b/docs/.vuepress/components/VuetifulBoardPlayground.vue
@@ -556,6 +556,7 @@ export default {
 
   .theme-swatches-name {
     display: block;
+    color: #232323;
     font-size: 14px;
   }
 

--- a/docs/.vuepress/components/VuetifulBoardPlayground.vue
+++ b/docs/.vuepress/components/VuetifulBoardPlayground.vue
@@ -491,7 +491,6 @@ export default {
   name: 'App',
   data() {
     return {
-      // TODO: Theme swatches에서 테마를 클릭하면 해당 테마의 이름을 가져와서 theme data에 바인딩
       theme: 'classic',
       layoutEditable: true,
       colNum: 12,

--- a/docs/.vuepress/components/VuetifulBoardPlayground.vue
+++ b/docs/.vuepress/components/VuetifulBoardPlayground.vue
@@ -597,9 +597,9 @@ export default {
 
 .editBtn {
   padding: 7px;
-  border: 1px solid white;
+  border: 1px solid #fff;
   border-radius: 5px;
-  background: white;
+  background: #fff;
   cursor: pointer;
 }
 </style>

--- a/docs/.vuepress/components/VuetifulBoardPlayground.vue
+++ b/docs/.vuepress/components/VuetifulBoardPlayground.vue
@@ -1,5 +1,11 @@
 <template>
-  <div>
+  <div id="app">
+    <!-- TODO: Monochrome color picker 서비스단으로 이동 -->
+    <div class="monochrome-color-picker">
+      <label clas="monochrome-color-picker-label" for="monochrome">Monochrome</label>
+      <input class="monochrome-color-picker-input" type="color" id="monochrome" name="monochrome" @change="setMonochromeColor" />
+    </div>
+
     <!-- TODO: Theme swatches 서비스단으로 이동 -->
     <ul class="theme-swatches">
       <li class="theme-swatches-item" @click="switchTheme">
@@ -316,7 +322,7 @@
             }
           },
           gridInfo: {
-            x: 0, y: 10, w: 6, h: 12, i: '2', static: false
+            x: 0, y: 10, w: 6, h: 10, i: '2', static: false
           },
         },
         {
@@ -371,7 +377,7 @@
             }
           },
           gridInfo: {
-            x: 6, y: 10, w: 6, h: 12, i: '3', static: false
+            x: 6, y: 10, w: 6, h: 10, i: '3', static: false
           },
         },
         {
@@ -434,7 +440,7 @@
             }
           },
           gridInfo: {
-            x: 0, y: 20, w: 6, h: 12, i: '4', static: false
+            x: 0, y: 20, w: 6, h: 10, i: '4', static: false
           },
         },
         {
@@ -520,7 +526,7 @@
             },
           },
           gridInfo: {
-            x: 6, y: 20, w: 6, h: 12, i: '5', static: false
+            x: 6, y: 20, w: 6, h: 10, i: '5', static: false
           }
         }
       ]"
@@ -529,7 +535,11 @@
 </template>
 
 <script>
+import VuetifulBoard from '../../../src/components/VuetifulBoard.vue';
+
 export default {
+  components: { VuetifulBoard },
+  name: 'App',
   data() {
     return {
       // TODO: Theme swatches에서 테마를 클릭하면 해당 테마의 이름을 가져와서 theme data에 바인딩
@@ -544,8 +554,11 @@ export default {
       // TODO: Theme swatches를 클릭하면 해당 테마의 이름을 가져와서 theme data에 바인딩
       this.theme = 'hoge';
     },
+    setMonochromeColor(event) {
+      this.theme = event.target.value;
+    }
   },
-}
+};
 </script>
 
 <style lang="scss" scoped>

--- a/docs/.vuepress/styles/index.styl
+++ b/docs/.vuepress/styles/index.styl
@@ -1,5 +1,10 @@
 
 div.theme-default-content:not(.custom) {
-  max-width: 1000px;
+  max-width: 1080px;
+  width: 100%;
 }
 
+div.page-nav:not(.custom) {
+  max-width: 1080px;
+  width: 100%;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,12 @@
 {
   "name": "vuetiful-board",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.0",
+      "version": "0.1.2",
+      "license": "MIT",
       "dependencies": {
         "core-js": "^3.6.5",
         "vue": "^2.6.11"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuetiful-board",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "scripts": {
     "dev": "cd dev && vue-cli-service serve",
     "build": "vue-cli-service build ./src/index.js --target lib",

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -2,15 +2,12 @@
 
 @import 'theme-colors';
 
-$color-bg: var(--color-bg);
-$color-text: var(--color-text);
-
 body {
   color: $color-text;
-  background-color: $color-bg;
+  background-color: $color-app-background;
 }
 
 .page {
   color: $color-text;
-  background-color: $color-bg;
+  background-color: $color-app-background;
 }

--- a/src/assets/scss/_common.scss
+++ b/src/assets/scss/_common.scss
@@ -1,1 +1,16 @@
 // common: 모든 컴포넌트에서 공용으로 사용되는 스타일을 지정
+
+@import 'theme-colors';
+
+$color-bg: var(--color-bg);
+$color-text: var(--color-text);
+
+body {
+  color: $color-text;
+  background-color: $color-bg;
+}
+
+.page {
+  color: $color-text;
+  background-color: $color-bg;
+}

--- a/src/assets/scss/_theme-colors.scss
+++ b/src/assets/scss/_theme-colors.scss
@@ -1,0 +1,9 @@
+:root {
+  --color-bg: #fff;
+  --color-text: #232323;
+
+  &[data-theme="dark"] {
+    --color-bg: #232323;
+    --color-text: #fff;
+  }
+}

--- a/src/assets/scss/_theme-colors.scss
+++ b/src/assets/scss/_theme-colors.scss
@@ -1,9 +1,14 @@
 :root {
-  --color-bg: #fff;
+  --color-app-background: #fff;
   --color-text: #232323;
 
   &[data-theme="dark"] {
-    --color-bg: #232323;
+    --color-app-background: #232323;
     --color-text: #fff;
+    --color-grid-item-background: #17191d;
   }
 }
+
+$color-app-background: var(--color-app-background);
+$color-text: var(--color-text);
+$color-grid-item-background: var(--color-grid-item-background);

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -269,7 +269,7 @@ export default {
 };
 </script>
 
-<style lang="scss" scoped>
+<style lang="scss">
 .vue-grid-item {
   touch-action: none;
 

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -93,18 +93,9 @@ export default {
   },
   data() {
     return {
-      gridInfos: {
-        type: Array,
-        required: false,
-      },
-      chartInfos: {
-        type: Array,
-        required: false,
-      },
-      palette: {
-        type: Array,
-        palette,
-      },
+      gridInfos: [],
+      chartInfos: [],
+      palette,
       isFirstMount: true,
     };
   },

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -203,13 +203,15 @@ export default {
           enabled: true,
           color: this.theme,
           shadeTo: 'light',
-          shadeIntensity: 0.8,
+          shadeIntensity: 0.9,
         },
       };
 
-      for (const info of this.chartInfos) {
-        this.$set(info.options, 'theme', monochromeTheme);
-      }
+      this.datasets.forEach(
+        item => (item.chartInfo.options.theme = monochromeTheme),
+      );
+
+      return this.bindChartInfos();
     },
   },
   created() {

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -178,7 +178,7 @@ export default {
         return item;
       });
     },
-    initFirstMountOption(selectedTheme) {
+    initFirstMountOptions(selectedTheme) {
       this.isFirstMount = false;
 
       return this.datasets.forEach(item => {
@@ -208,7 +208,7 @@ export default {
       const selectedTheme = palette.filter(theme => this.theme === theme.name);
 
       if (this.isFirstMount) {
-        this.initFirstMountOption(selectedTheme);
+        this.initFirstMountOptions(selectedTheme);
       } else {
         this.datasets.forEach(item => {
           item.chartInfo.options.colors = selectedTheme[0].colors;

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -98,6 +98,7 @@ export default {
         type: Array,
         palette,
       },
+      isFirstMount: true,
     };
   },
   methods: {
@@ -193,9 +194,19 @@ export default {
 
       const selectedTheme = palette.filter(theme => this.theme === theme.name);
 
-      return this.datasets.forEach(
-        item => (item.chartInfo.options.colors = selectedTheme[0].colors),
-      );
+      if (this.isFirstMount) {
+        this.isFirstMount = false;
+
+        return this.datasets.forEach(
+          item => (item.chartInfo.options.colors = selectedTheme[0].colors),
+        );
+      } else {
+        this.datasets.forEach(
+          item => (item.chartInfo.options.colors = selectedTheme[0].colors),
+        );
+
+        return this.bindChartInfos();
+      }
     },
     setMonochromeColor() {
       const monochromeTheme = {

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -38,6 +38,10 @@ export default {
       type: String,
       default: palette[0].name,
     },
+    darkMode: {
+      type: Boolean,
+      default: false,
+    },
     colNum: {
       type: Number,
       required: true,
@@ -69,6 +73,7 @@ export default {
                 },
                 colors: palette[0].colors,
                 theme: {
+                  mode: 'light',
                   monochrome: {
                     enabled: false,
                     shadeTo: 'light',
@@ -97,6 +102,14 @@ export default {
       chartInfos: [],
       palette,
       isFirstMount: true,
+      darkModeColorOptions: {
+        background: '#000',
+        foreColor: '#fff',
+      },
+      lightModeColorOptions: {
+        background: '#fff',
+        foreColor: '#000',
+      },
     };
   },
   methods: {
@@ -185,6 +198,7 @@ export default {
         // TODO: colors와 theme에 (로컬 스토리지 등으로부터) 이전에 설정해두었던 테마, 컬러, 다크 모드의 옵션 값을 담기
         item.chartInfo.options.colors = selectedTheme[0].colors;
         item.chartInfo.options.theme = {
+          mode: this.isDarkMode(),
           monochrome: {
             enabled: false,
             shadeTo: 'light',
@@ -197,6 +211,12 @@ export default {
       return this.datasets.forEach(
         item => (item.chartInfo.options.colors = palette[0].colors),
       );
+    },
+    isDarkMode() {
+      return this.darkMode ? 'dark' : 'light';
+    },
+    isMonochromeMode() {
+      return this.theme.startsWith('#') ? true : false;
     },
     setTheme() {
       if (!palette.some(theme => theme.name === this.theme)) {
@@ -211,10 +231,14 @@ export default {
         this.initFirstMountOptions(selectedTheme);
       } else {
         this.datasets.forEach(item => {
+          item.chartInfo.chart = this.darkMode
+            ? this.darkModeColorOptions
+            : this.lightModeColorOptions;
           item.chartInfo.options.colors = selectedTheme[0].colors;
           item.chartInfo.options.theme = {
+            mode: this.isDarkMode(),
             monochrome: {
-              enabled: false,
+              enabled: this.isMonochromeMode(),
               shadeTo: 'light',
               shadeIntensity: 0.9,
             },
@@ -228,8 +252,9 @@ export default {
     },
     setMonochromeColor() {
       const monochromeTheme = {
+        mode: this.isDarkMode(),
         monochrome: {
-          enabled: true,
+          enabled: this.isMonochromeMode(),
           color: this.theme,
           shadeTo: 'light',
           shadeIntensity: 0.9,
@@ -241,6 +266,46 @@ export default {
       );
 
       return this.bindChartInfos();
+    },
+    setDarkMode() {
+      const currentThemeOptions = {
+        mode: this.isDarkMode(),
+        monochrome: {
+          enabled: this.isMonochromeMode(),
+          color: this.theme,
+          shadeTo: 'light',
+          shadeIntensity: 0.9,
+        },
+      };
+
+      this.datasets.forEach(item => {
+        item.chartInfo.options.theme = currentThemeOptions;
+        item.chartInfo.options.chart = this.darkModeColorOptions;
+
+        return item;
+      });
+
+      this.bindChartInfos();
+    },
+    setLightMode() {
+      const currentThemeOptions = {
+        mode: this.isDarkMode(),
+        monochrome: {
+          enabled: this.isMonochromeMode(),
+          color: this.theme,
+          shadeTo: 'light',
+          shadeIntensity: 0.9,
+        },
+      };
+
+      this.datasets.forEach(item => {
+        item.chartInfo.options.theme = currentThemeOptions;
+        item.chartInfo.options.chart = this.lightModeColorOptions;
+
+        return item;
+      });
+
+      this.bindChartInfos();
     },
   },
   created() {
@@ -255,6 +320,9 @@ export default {
   watch: {
     theme() {
       this.theme.startsWith('#') ? this.setMonochromeColor() : this.setTheme();
+    },
+    darkMode() {
+      this.darkMode ? this.setDarkMode() : this.setLightMode();
     },
   },
 };

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -103,12 +103,12 @@ export default {
       palette,
       isFirstMount: true,
       darkModeColorOptions: {
-        background: '#000',
+        background: 'rgba(65, 65, 65, 0.5)',
         foreColor: '#fff',
       },
       lightModeColorOptions: {
         background: '#fff',
-        foreColor: '#000',
+        foreColor: '#302f2f',
       },
     };
   },

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -197,6 +197,20 @@ export default {
         item => (item.chartInfo.options.colors = selectedTheme[0].colors),
       );
     },
+    setMonochromeColor() {
+      const monochromeTheme = {
+        monochrome: {
+          enabled: true,
+          color: this.theme,
+          shadeTo: 'light',
+          shadeIntensity: 0.8,
+        },
+      };
+
+      for (const info of this.chartInfos) {
+        this.$set(info.options, 'theme', monochromeTheme);
+      }
+    },
   },
   created() {
     this.validateProps();
@@ -206,6 +220,11 @@ export default {
     this.addUniqueId();
 
     !this.theme ? this.setDefaultTheme() : this.setTheme();
+  },
+  watch: {
+    theme() {
+      this.theme.startsWith('#') ? this.setMonochromeColor() : this.setTheme();
+    },
   },
 };
 </script>

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -187,6 +187,21 @@ export default {
         return item;
       });
     },
+    initFirstMountOption(selectedTheme) {
+      this.isFirstMount = false;
+
+      return this.datasets.forEach(item => {
+        // TODO: colors와 theme에 (로컬 스토리지 등으로부터) 이전에 설정해두었던 테마, 컬러, 다크 모드의 옵션 값을 담기
+        item.chartInfo.options.colors = selectedTheme[0].colors;
+        item.chartInfo.options.theme = {
+          monochrome: {
+            enabled: false,
+            shadeTo: 'light',
+            shadeIntensity: 0.9,
+          },
+        };
+      });
+    },
     setDefaultTheme() {
       return this.datasets.forEach(
         item => (item.chartInfo.options.colors = palette[0].colors),
@@ -202,18 +217,7 @@ export default {
       const selectedTheme = palette.filter(theme => this.theme === theme.name);
 
       if (this.isFirstMount) {
-        this.isFirstMount = false;
-
-        return this.datasets.forEach(item => {
-          item.chartInfo.options.colors = selectedTheme[0].colors;
-          item.chartInfo.options.theme = {
-            monochrome: {
-              enabled: false,
-              shadeTo: 'light',
-              shadeIntensity: 0.9,
-            },
-          };
-        });
+        this.initFirstMountOption(selectedTheme);
       } else {
         this.datasets.forEach(item => {
           item.chartInfo.options.colors = selectedTheme[0].colors;
@@ -270,7 +274,6 @@ export default {
   touch-action: none;
 
   &:not(.vue-grid-placeholder) {
-    background: #fff;
     border-radius: 13px;
     box-shadow: rgba(0, 0, 0, 0.08) 0px 4px 10px;
   }

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -225,6 +225,9 @@ export default {
       return this.theme.startsWith('#') ? true : false;
     },
     setTheme() {
+      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하고,
+      //       테마, 모노크롬, 다크모드 적용 함수에서 옵션 추가후 bindChartInfos를 실행하는 로직이 반복되고 있는 부분 수정 필요
+
       if (!palette.some(theme => theme.name === this.theme)) {
         return console.error(
           '[vuetiful-board warn] Invalid theme: Please check the theme name.',
@@ -260,6 +263,8 @@ export default {
       }
     },
     setMonochromeColor() {
+      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하고,
+      //       테마, 모노크롬, 다크모드 적용 함수에서 옵션 추가후 bindChartInfos를 실행하는 로직이 반복되고 있는 부분 수정 필요
       const monochromeTheme = {
         mode: this.isDarkMode(),
         monochrome: {
@@ -285,6 +290,8 @@ export default {
       return this.bindChartInfos();
     },
     setDarkMode() {
+      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하고,
+      //       테마, 모노크롬, 다크모드 적용 함수에서 옵션 추가후 bindChartInfos를 실행하는 로직이 반복되고 있는 부분 수정 필요
       document.documentElement.dataset.theme = this.isDarkMode();
 
       const currentThemeOptions = {
@@ -310,6 +317,8 @@ export default {
       this.bindChartInfos();
     },
     setLightMode() {
+      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하고,
+      //       테마, 모노크롬, 다크모드 적용 함수에서 옵션 추가후 bindChartInfos를 실행하는 로직이 반복되고 있는 부분 수정 필요
       document.documentElement.dataset.theme = this.isDarkMode();
 
       const currentThemeOptions = {

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -196,15 +196,21 @@ export default {
 
       return this.datasets.forEach(item => {
         // TODO: colors와 theme에 (로컬 스토리지 등으로부터) 이전에 설정해두었던 테마, 컬러, 다크 모드의 옵션 값을 담기
-        item.chartInfo.options.colors = selectedTheme[0].colors;
-        item.chartInfo.options.theme = {
-          mode: this.isDarkMode(),
-          monochrome: {
-            enabled: false,
-            shadeTo: 'light',
-            shadeIntensity: 0.9,
-          },
-        };
+        (item.chartInfo.options.colors = selectedTheme[0].colors),
+          (item.chartInfo.options.theme = {
+            mode: this.isDarkMode(),
+            monochrome: {
+              enabled: false,
+              shadeTo: 'light',
+              shadeIntensity: 0.9,
+            },
+          }),
+          (item.chartInfo.options.chart = this.darkMode
+            ? { ...item.chartInfo.options.chart, ...this.darkModeColorOptions }
+            : {
+                ...this.lightModeColorOptions,
+                ...item.chartInfo.options.chart,
+              });
       });
     },
     setDefaultTheme() {
@@ -231,9 +237,6 @@ export default {
         this.initFirstMountOptions(selectedTheme);
       } else {
         this.datasets.forEach(item => {
-          item.chartInfo.chart = this.darkMode
-            ? this.darkModeColorOptions
-            : this.lightModeColorOptions;
           item.chartInfo.options.colors = selectedTheme[0].colors;
           item.chartInfo.options.theme = {
             mode: this.isDarkMode(),
@@ -243,6 +246,12 @@ export default {
               shadeIntensity: 0.9,
             },
           };
+          item.chartInfo.options.chart = this.darkMode
+            ? { ...item.chartInfo.options.chart, ...this.darkModeColorOptions }
+            : {
+                ...this.lightModeColorOptions,
+                ...item.chartInfo.options.chart,
+              };
 
           return item;
         });
@@ -261,9 +270,17 @@ export default {
         },
       };
 
-      this.datasets.forEach(
-        item => (item.chartInfo.options.theme = monochromeTheme),
-      );
+      this.datasets.forEach(item => {
+        item.chartInfo.options.theme = monochromeTheme;
+        item.chartInfo.options.chart = this.darkMode
+          ? { ...item.chartInfo.options.chart, ...this.darkModeColorOptions }
+          : {
+              ...this.lightModeColorOptions,
+              ...item.chartInfo.options.chart,
+            };
+
+        return item;
+      });
 
       return this.bindChartInfos();
     },
@@ -280,7 +297,10 @@ export default {
 
       this.datasets.forEach(item => {
         item.chartInfo.options.theme = currentThemeOptions;
-        item.chartInfo.options.chart = this.darkModeColorOptions;
+        item.chartInfo.options.chart = {
+          ...item.chartInfo.options.chart,
+          ...this.darkModeColorOptions,
+        };
 
         return item;
       });
@@ -300,7 +320,10 @@ export default {
 
       this.datasets.forEach(item => {
         item.chartInfo.options.theme = currentThemeOptions;
-        item.chartInfo.options.chart = this.lightModeColorOptions;
+        item.chartInfo.options.chart = {
+          ...item.chartInfo.options.chart,
+          ...this.lightModeColorOptions,
+        };
 
         return item;
       });

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -360,4 +360,8 @@ export default {
     box-shadow: rgba(0, 0, 0, 0.08) 0px 4px 10px;
   }
 }
+
+.apexcharts-svg {
+  border-radius: 13px;
+}
 </style>

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -103,7 +103,7 @@ export default {
       palette,
       isFirstMount: true,
       darkModeColorOptions: {
-        background: 'rgba(70, 70, 70, 0.2)',
+        background: 'rgba(98, 104, 113, 0.35)',
         foreColor: '#fff',
       },
       lightModeColorOptions: {
@@ -356,9 +356,11 @@ export default {
 </script>
 
 <style lang="scss">
+@import '../assets/scss/theme-colors';
+
 .vue-grid-item {
   touch-action: none;
-  /* background-color: $white; */
+  background-color: $color-grid-item-background;
 
   &:not(.vue-grid-placeholder) {
     border-radius: 13px;

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -68,6 +68,13 @@ export default {
                   type: null,
                 },
                 colors: palette[0].colors,
+                theme: {
+                  monochrome: {
+                    enabled: false,
+                    shadeTo: 'light',
+                    shadeIntensity: 0.9,
+                  },
+                },
               },
             },
             gridInfo: {
@@ -197,13 +204,29 @@ export default {
       if (this.isFirstMount) {
         this.isFirstMount = false;
 
-        return this.datasets.forEach(
-          item => (item.chartInfo.options.colors = selectedTheme[0].colors),
-        );
+        return this.datasets.forEach(item => {
+          item.chartInfo.options.colors = selectedTheme[0].colors;
+          item.chartInfo.options.theme = {
+            monochrome: {
+              enabled: false,
+              shadeTo: 'light',
+              shadeIntensity: 0.9,
+            },
+          };
+        });
       } else {
-        this.datasets.forEach(
-          item => (item.chartInfo.options.colors = selectedTheme[0].colors),
-        );
+        this.datasets.forEach(item => {
+          item.chartInfo.options.colors = selectedTheme[0].colors;
+          item.chartInfo.options.theme = {
+            monochrome: {
+              enabled: false,
+              shadeTo: 'light',
+              shadeIntensity: 0.9,
+            },
+          };
+
+          return item;
+        });
 
         return this.bindChartInfos();
       }

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -103,12 +103,12 @@ export default {
       palette,
       isFirstMount: true,
       darkModeColorOptions: {
-        background: 'rgba(65, 65, 65, 0.5)',
+        background: 'rgba(70, 70, 70, 0.2)',
         foreColor: '#fff',
       },
       lightModeColorOptions: {
         background: '#fff',
-        foreColor: '#302f2f',
+        foreColor: '#232323',
       },
     };
   },
@@ -285,6 +285,8 @@ export default {
       return this.bindChartInfos();
     },
     setDarkMode() {
+      document.documentElement.dataset.theme = this.isDarkMode();
+
       const currentThemeOptions = {
         mode: this.isDarkMode(),
         monochrome: {
@@ -308,6 +310,8 @@ export default {
       this.bindChartInfos();
     },
     setLightMode() {
+      document.documentElement.dataset.theme = this.isDarkMode();
+
       const currentThemeOptions = {
         mode: this.isDarkMode(),
         monochrome: {
@@ -354,6 +358,7 @@ export default {
 <style lang="scss">
 .vue-grid-item {
   touch-action: none;
+  /* background-color: $white; */
 
   &:not(.vue-grid-placeholder) {
     border-radius: 13px;

--- a/vue.config.js
+++ b/vue.config.js
@@ -6,6 +6,7 @@ module.exports = {
     loaderOptions: {
       scss: {
         additionalData: `
+          @import "~@/assets/scss/theme-colors.scss";
           @import "~@/assets/scss/variables.scss";
           @import "~@/assets/scss/mixins.scss";
         `,

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,4 +1,7 @@
 module.exports = {
+  devServer: {
+    host: 'localhost',
+  },
   css: {
     loaderOptions: {
       scss: {


### PR DESCRIPTION
# 작업 내용

- [x] color picker에서 선택된 컬러를 바탕으로, 차트 색상을 monochrome으로 변환 기능 구현
- [x] theme swatches에서 테마 선택 시, theme 변경
- [x] monochrome ⇄ theme 변환 기능 지원
- [x] 차트 다크 모드 구현
- [x] grid-item 다크 모드 적용
- [x] 전체 페이지 다크 모드 적용
- [x] 다크 모드 유지한 채 monochrome ⇄ 테마 변환 기능 지원
- [x] 0.1.2 ⇨ 0.1.3 버전 업데이트

# 구현 결과 화면

![dark theme monochrome](https://user-images.githubusercontent.com/50080535/132136727-4c954a33-26c4-4072-9210-844cea083b8e.gif)

# 상세 내용

(현재 상세 내용 작성중입니다. 작성 완료되면 코멘트로 멘션드리겠습니다!)

## 1. 색 선택을 위한 color picker 구현

data theme의 기본값은 테마명(ex. classic, green, vintage 등)이기 때문에
초기 마운트때는 테마를 바탕으로 차트를 출력하게 됩니다.

하지만 input color picker에서 컬러를 선택하면 `setMonochromeColor`함수가 실행되면서,
input color picker에서 선택한 컬러값을 받아옵니다. 받아온 컬러값을 data인 `theme`에 담습니다 (테마명→hex code로 덮어씀).

VuetifulBoard는 theme props으로 받은 색상 값을 바탕으로
모노크롬 설정 함수를 실행해서 모노크롬 테마를 설정하게 됩니다.

```vue
<!-- dev/src/App.vue -->

<template>
   <div class="monochrome-color-picker">
      <label clas="monochrome-color-picker-label" for="monochrome">Monochrome</label>
      <input class="monochrome-color-picker-input" type="color" id="monochrome" name="monochrome" @change="setMonochromeColor" />
   </div>

   <vuetiful-board
     :theme="theme"
     ...중략
   />
</template>

<script>
import VuetifulBoard from '../../src/components/VuetifulBoard.vue';

export default {
  components: { VuetifulBoard },
  name: 'App',
  data() {
    return {
      theme: 'rainbow',
    }
  },
  methods: {
    setMonochromeColor(event) {
      this.theme = event.target.value;
    }
  },
};
</script>
```

## 2. 선택된 컬러를 바탕으로, 차트 색상을 monochrome으로 변환하는 기능 구현

상세한 로직은 아래 첨부한 코드에 주석을 달아두었습니다.

```vue
<!-- src/components/VuetifulBoard.vue -->
<template>
  <div>
    <grid-layout
      :layout.sync="gridInfos"
      ...중략
      <!-- grid-layout의 렌더링 후에 chart를 마운트 해줌 (grid-layout이 렌더링 된 후에 bindChartInfos를 실행) -->
      @layout-ready="bindChartInfos"
    >
      <grid-item
        v-for="(item, index) in gridInfos"
        ...중략
      >
        <apex-charts
          v-if="chartInfos[index]"
          :type="chartInfos[index].options.type"
          :series="chartInfos[index].series"
          :options="chartInfos[index].options"
        />
      </grid-item>
    </grid-layout>
  </div>
</template>

<script>
export default {
  props: {
    theme: {
      type: String,
      default: palette[0].name,
    },
    datasets: {
      type: Array,
      required: true,
      default: ...중략
    },
  },
  data() {
    return {
      chartInfos: {
        type: Array,
        required: false,
      },
    };
  },
  methods: {
    bindChartInfos() {
      // 자식 요소의 세부적인 변화까지 감지하지 못하기 때문에, 데이터를 최상위 단위로 뽑아내기 위해
      // datasets.chartInfo을 chartInfos에 바인딩
      this.chartInfos = this.datasets.map(item => item.chartInfo);
    },
    setMonochromeColor() {
      const monochromeTheme = {
        monochrome: {
          enabled: true,
          color: this.theme,
          shadeTo: 'light',
          shadeIntensity: 0.9,
        },
      };

      // this.datasets에 모노크롬 테마 설정을 담아준 후
      this.datasets.forEach(
        item => (item.chartInfo.options.theme = monochromeTheme),
      );

      // this.datasets.chartInfo를 ChartInfos에 바인딩(차트 정보는 ChartInfos를 바탕으로 출력되기 때문)
      return this.bindChartInfos();
    },
  },
  watch: {
    // 지정한 대상(theme)의 값이 변경될 때마다 테마를 변경해주기 위해, watch를 사용
    theme() {
      // theme가 '#'부터 시작＝hex code일 때 → setMonochromeColor 실행
      // theme가 '#'부터 시작하지 않을 때＝일반 테마(ex. classic, green, vintage 등)일 때 → setTheme 실행
      this.theme.startsWith('#') ? this.setMonochromeColor() : this.setTheme();
    },
  },
}
</script>
```

### 2-1. 결과 화면

설정한 색상을 바탕으로, monochrome 색상이 적용됨.
모노크롬 색상을 처음 설정할 시에 options.theme 프로퍼티가 추가된 모습과
컬러 변경 시 props, data 내의 options.theme.color의 hex code 값도 갱신되고 있는 모습.

(용량 제한 관계상, 화질이 좋지 않은 점 양해 부탁드립니다)

![monochrome done](https://user-images.githubusercontent.com/50080535/132033258-4f771499-dddd-4928-9e71-fd377cf62994.gif)

## 3. theme swatches에서 테마 선택 시, theme 변경

`VuetifulBoard`는 서비스단으로부터, `theme` prop에 theme name을 값으로 받게 됩니다.
prop으로 받은 theme 값을 바탕으로, `setTheme` 함수에서 테마 이름에 해당하는 컬러를 차트 컬러로 적용시킵니다.

차트는 `chartInfos`에 담긴 차트 데이터와 옵션값을 바탕으로 출력됩니다.

첫 마운트 시에는 grid의 렌더링 후에 chart를 출력시키기 위해
vue-grid-layout에서 제공하는 `layout-ready`라는 내장 메소드를 이용해서
ChartInfos에 값을 바인딩 하는 함수(`bindChartInfos`)의 실행을 지연시키고 있습니다. (아래 코드)

```vue
<grid-layout
      @layout-ready="bindChartInfos"
>
```

다만 첫 마운트 후에 this.datasets의 데이터가 변경되는 경우에는,
데이터이 갱신된 후에 다시 한번 `bindChartInfos`를 실행시켜 chartInfos에 데이터를 바인딩해줄 필요가 있었습니다.

따라서, data에 `isFirstMount`라는 플래그를 만들고
아래와 같이 `setTheme` 내에서 if문으로 첫 마운트의 경우와 첫 마운트가 아닌 경우의 로직을 분리해서 작성했습니다.

하지만 chartInfo에 색상을 넣어주는 로직(forEach문) 자체는
첫 마운트와, 첫 마운트 이후 모두 동일하기 때문에 마운트 상황 관계 없이 중복되고 있는 문제점이 있습니다.
(사실상 `bindChartInfos` 함수를 실행시켜주냐 안시켜주냐의 유무의 차이)

이 부분은 추후 리팩토링이 필요하다고 생각합니다.

```vue
<!-- src/components/VuetifulBoard.vue -->
<script>
  data() {
    return {
      isFirstMount: true,  // 초기값은 true
    };
  },
 methods: {
  setTheme() {
      // ...중략
      const selectedTheme = palette.filter(theme => this.theme === theme.name); // 현재 선택된 테마

      if (this.isFirstMount) {
        this.isFirstMount = false;  // 첫마운트 후에는 false로 플래그 변경

         // 선택된 테마의 컬러를 바로 차트 color에 설정후 리턴
        return this.datasets.forEach(item => {
          item.chartInfo.options.colors = selectedTheme[0].colors;
          item.chartInfo.options.theme = {
            monochrome: {
              enabled: false,
              shadeTo: 'light',
              shadeIntensity: 0.9,
            },
          };
        });
      } else {
        // 첫 마운트가 아닌 경우
        this.datasets.forEach(item => {
          item.chartInfo.options.colors = selectedTheme[0].colors;
          item.chartInfo.options.theme = {
            monochrome: {
              enabled: false,
              shadeTo: 'light',
              shadeIntensity: 0.9,
            },
          };

          return item;
        });

        // chartInfos에 바인딩 실행
        return this.bindChartInfos();
      }
    },
  }
}
</script>
```

### 3-1. 결과 화면

theme swatches에서 테마 선택 시, 테마가 switch되는 모습.

![change_theme](https://user-images.githubusercontent.com/50080535/132091816-aa0dfb29-6f17-4d3a-b98b-cb773c1d01f5.gif)


## 4. monochrome ⇄ 테마 변환 기능 지원

monochrome 컬러로 설정 후, theme swatches를 클릭하여 일반 테마로 다시 switch할 수 있도록 지원했습니다.

ApexCharts의 컬러 및 테마 설정에 대한 우선순위는 다음과 같았습니다.

1. monochrome
2. colors (우리의 라이브러리로 치면 classic, green 등의 상세 테마 색상)
3. palette (ApexCharts에서 기본적으로 제공하는 팔레트. 우리 라이브러리에는 도입X)

monochrome의 우선순위가 가장 높았고,
colors의 값 유무와 monochrome의 옵션 정보 유무(color, shadeTo 등) 관계없이
`options.theme.monochrome.enabled`의 값이 true일 경우에만 monochrome이 적용되는 형식이었습니다.

```javascript
{
  options: {
     colors: [#333, #fff],
     monochrome: {
          // colors, shadeTo, shadeIntensity의 값이 존재해도 enabled가 false이면
          // monochrome은 적용되지 않음
          enabled: true,
          color: this.theme,
          shadeTo: 'light',
          shadeIntensity: 0.9,
     },
  }
}
```

watch에서 theme값의 변화에 따라 `setMonochromeColor` 또는 `setTheme`함수를 실행시키고 있습니다.

monochrome 설정 후 일반 테마로 변경 시에 테마 switching이 이루어지도록,
`setTheme`함수에서 `options.theme.monochrome.enabled`를 false로 변경하는 구문을 추가했습니다.

```vue
<script>
methods: {
  setTheme() {
      // ...중략
      const selectedTheme = palette.filter(theme => this.theme === theme.name); // 현재 선택된 테마

      if (this.isFirstMount) {
        this.isFirstMount = false;  // 첫마운트 후에는 false로 플래그 변경

         // 선택된 테마의 컬러를 바로 차트 color에 설정후 리턴
        return this.datasets.forEach(item => {
          item.chartInfo.options.colors = selectedTheme[0].colors;
          // ↓ monochrome.enabled를 false로 변경
          item.chartInfo.options.theme = {
            monochrome: {
              enabled: false,
              shadeTo: 'light',
              shadeIntensity: 0.9,
            },
          };
        });
      } else {
        // 첫 마운트가 아닌 경우
        this.datasets.forEach(item => {
          item.chartInfo.options.colors = selectedTheme[0].colors;
          // ↓ monochrome.enabled를 false로 변경
          item.chartInfo.options.theme = {
            monochrome: {
              enabled: false,
              shadeTo: 'light',
              shadeIntensity: 0.9,
            },
          };

          return item;
        });

        // chartInfos에 바인딩 실행
        return this.bindChartInfos();
      }
    },
  }
  watch: {
    // 지정한 대상(theme)의 값이 변경될 때마다 테마를 변경해주기 위해, watch를 사용
    theme() {
      // theme가 '#'부터 시작＝hex code일 때 → setMonochromeColor 실행
      // theme가 '#'부터 시작하지 않을 때＝일반 테마(ex. classic, green, vintage 등)일 때 → setTheme 실행
      this.theme.startsWith('#') ? this.setMonochromeColor() : this.setTheme();
    },
  },
</script>
```
