### PR TITLE
[김지현] Grid Layout 요소 디폴트 value 수정 및 Apexchart Default width & height 추가

### DIFF
--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -20,6 +20,8 @@
       >
         <apex-charts
           v-if="chartInfos[index]"
+          width="100%"
+          height="100%"
           :type="chartInfos[index].options.type"
           :series="chartInfos[index].series"
           :options="chartInfos[index].options"

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -72,7 +72,7 @@ export default {
             },
             gridInfo: {
               id: this.$uuid.v4(),
-              x: Math.round(this.colNum / 1),
+              x: this.colNum,
               y: Math.round(this.colNum / 3),
               w: Math.round(this.colNum / 2),
               h: this.colNum,


### PR DESCRIPTION

# 수정 사항

```vue
x: Math.round(this.colNum / 1)

위 코드를 

x: this.colNum

위와 같이 수정 완료하였습니다. 

```

dataset 자체가 없을 때 그려지는 그리드 레이아웃과 관련된 디폴트 요소 관련 수정 사항이 생겨 새로 PR을 생성하게 되었습니다. 


------

더불어, 기존에는 아래와 같은 이슈가 발생 했었습니다. 

https://user-images.githubusercontent.com/81766172/132147893-89b75cf7-da6a-4863-8914-cd08e7493002.mov

화면에서 grid item (각 그리드)의 height가 줄어들 때, `에이펙스 차트` 의 크기 또한 반응형으로 줄어드는 것이 아니라 그리드를 빠져나오는 (사이즈가 잘 맞춰지지 않는) 이슈였습니다. 따라서 이 부분에 대해서 심각하게 고민하고, 여러 가지 메소드들을 추가해보는 과정을 거친 끝에 

```vue

<apex-charts
          v-if="chartInfos[index]"
          width="100%"
          height="100%"
          :type="chartInfos[index].options.type"
          :series="chartInfos[index].series"
          :options="chartInfos[index].options"
        />

```



위와 같이 `width="100%", height="100%"` 로 디폴트 값을 주니 그러한 이슈가 사라졌습니다. (화면 폭 자체가 작아서 차트가 다소 찌그러져 보이는 점에 대해서는 양해 부탁드립니다.) 


https://user-images.githubusercontent.com/81766172/132148026-863827c4-b132-49a0-b978-f2de931ac39c.mov



