### PR TITLE
[감하영/Hotfix] datasets 업데이트 시 ID 추가 & 다크 모드 전환 시 이전 테마 색상 사라지는 버그 해결

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "vuetiful-board",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.6",
+      "version": "0.1.7",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuetiful-board",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "scripts": {
     "dev": "cd dev && vue-cli-service serve",
     "build": "vue-cli-service build ./src/index.js --target lib",

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="vuetiful-board">
     <grid-layout
       :layout.sync="gridInfos"
       :col-num="colNum"

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -20,11 +20,12 @@
       >
         <apex-charts
           v-if="chartInfos[index]"
-          width="100%"
-          height="100%"
+          :key="chartInfos[index].id"
           :type="chartInfos[index].options.type"
           :series="chartInfos[index].series"
           :options="chartInfos[index].options"
+          width="100%"
+          height="100%"
         />
       </grid-item>
     </grid-layout>
@@ -202,7 +203,7 @@ export default {
       this.chartInfos = this.datasets.map(item => item.chartInfo);
     },
     addUniqueId() {
-      this.datasets.forEach(item => {
+      return this.datasets.forEach(item => {
         item.id = item.id ?? this.$uuid.v4();
         item.chartInfo.id = item.chartInfo.id ?? this.$uuid.v4();
         item.gridInfo.id = item.gridInfo.id ?? this.$uuid.v4();
@@ -278,6 +279,7 @@ export default {
           return item;
         });
 
+        this.addUniqueId();
         return this.bindChartInfos();
       }
     },
@@ -303,6 +305,7 @@ export default {
         return item;
       });
 
+      this.addUniqueId();
       return this.bindChartInfos();
     },
     setDarkMode() {
@@ -330,6 +333,7 @@ export default {
         return item;
       });
 
+      this.addUniqueId();
       this.bindChartInfos();
     },
     setLightMode() {

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -113,14 +113,21 @@ export default {
         background: '#fff',
         foreColor: '#232323',
       },
+      previousThemeColors: [],
     };
   },
   watch: {
+    datasets(newValue, oldValue) {
+      const oldColors = oldValue[0].chartInfo.options.colors;
+      this.savePreviousThemeColors(oldColors);
+    },
     theme() {
       this.theme.startsWith('#') ? this.setMonochromeColor() : this.setTheme();
     },
     darkMode() {
-      this.darkMode ? this.setDarkMode() : this.setLightMode();
+      this.darkMode
+        ? this.setDarkMode(this.previousThemeColors)
+        : this.setLightMode(this.previousThemeColors);
     },
   },
   created() {
@@ -244,6 +251,9 @@ export default {
     isMonochromeMode() {
       return this.theme.startsWith('#') ? true : false;
     },
+    savePreviousThemeColors(oldColors) {
+      return (this.previousThemeColors = oldColors);
+    },
     setTheme() {
       // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하고,
       //       테마, 모노크롬, 다크모드 적용 함수에서 옵션 추가후 bindChartInfos를 실행하는 로직이 반복되고 있는 부분 수정 필요
@@ -308,7 +318,7 @@ export default {
       this.addUniqueId();
       return this.bindChartInfos();
     },
-    setDarkMode() {
+    setDarkMode(oldColors) {
       // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하고,
       //       테마, 모노크롬, 다크모드 적용 함수에서 옵션 추가후 bindChartInfos를 실행하는 로직이 반복되고 있는 부분 수정 필요
       document.documentElement.dataset.theme = this.isDarkMode();
@@ -324,6 +334,7 @@ export default {
       };
 
       this.datasets.forEach(item => {
+        item.chartInfo.options.colors = oldColors;
         item.chartInfo.options.theme = currentThemeOptions;
         item.chartInfo.options.chart = {
           ...item.chartInfo.options.chart,
@@ -336,7 +347,7 @@ export default {
       this.addUniqueId();
       this.bindChartInfos();
     },
-    setLightMode() {
+    setLightMode(oldColors) {
       // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하고,
       //       테마, 모노크롬, 다크모드 적용 함수에서 옵션 추가후 bindChartInfos를 실행하는 로직이 반복되고 있는 부분 수정 필요
       document.documentElement.dataset.theme = this.isDarkMode();
@@ -352,6 +363,7 @@ export default {
       };
 
       this.datasets.forEach(item => {
+        item.chartInfo.options.colors = oldColors;
         item.chartInfo.options.theme = currentThemeOptions;
         item.chartInfo.options.chart = {
           ...item.chartInfo.options.chart,

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -373,6 +373,7 @@ export default {
         return item;
       });
 
+      this.addUniqueId();
       this.bindChartInfos();
     },
   },


### PR DESCRIPTION
# Hotfix 이유

1. 서비스단에서 `vuetiful-board`를 사용했을 때, 차트의 각종 정보가 저장되어 있는 datasets의 데이터와
theme, darkMode 등의 상태는 제대로 update가 이루어지고 있었지만,
HTML 엘리먼트가 업데이트 되지 않아 차트 색상이 변경되지 않는 버그 발생

2. (1번 해결 후 발견함) 다크 모드 전환 시, 이전의 테마 색상이 유지되지 않는 버그 발생

# 상황 전개

1. 원인 : datasets 업데이트 시 re-render가 일어나지 않음.
   * **해결책** : Vue에서는 요소의 key 값이 변경되는 경우, 해당 요소를 업데이트함 ([참고 자료](https://velog.io/@byungjur_96/vue.js-%EC%BB%B4%ED%8F%AC%EB%84%8C%ED%8A%B8%EC%97%98%EB%A6%AC%EB%A8%BC%ED%8A%B8-re-rendering-%ED%95%98%EB%8A%94-%EB%B2%95))
      * 하지만 `vuetiful-board`에 key값이 누락되어 있었고, 테마 변경 & 다크 모드 전환 등으로 data 및 props가 업데이트 될 때 ID가 보존되지 않는 버그가 존재했음
      * `chartInfos`에 새로 담은 값을 바탕으로 차트를 렌더링하기 때문에, 매번 업데이트 시 ID를 포함한 모든 옵션을 다시 한 번 `chartInfos`에 추가해줘야하는 번거로움이 존재..ID를 추가해주는 부분이 누락되어 있었음.
   * **결과** : 테마 변경 & 다크 모드 전환 등으로 data 및 props가 업데이트 될 때 `addUniqueId` 함수를 추가로 실행시켜주며 ID를 추가해주는 것으로 해결


2. 원인 : 다크/라이트모드 전환 시 (datasets 업데이트 시), 이전 팔레트의 컬러값이 `chartInfos`에 존재하지 않았기 때문
   * **해결책 및 결과** : datasets 내의 이전 팔레트 컬러값을 `previousThemeColors`라는 data에 별도로 저장해두고, 다크/라이트 모드 전환 시 이전 팔레트의 `previousThemeColors`에 담긴 컬러값을 `chartInfos.options.colors`에 추가

# 향후 과제

1번, 2번 모두 동일한 원인으로 발생했던 버그였습니다.

이번 라이브러리의 주된 오브젝트가 차트라는 특성상, 기존의 각종 데이터(series, ID, 이전 테마값 등)를 유지한 채로 새로운 옵션(새로운 테마, 다크모드 반전, 새로운 모노크롬 색상 등)을 추가해주어야하는 부분이 지켜져야합니다.
하지만 현재의 로직은 datasets.chartInfo와는 또다른 data인 `chartInfos`의 값을 바탕으로 차트가 렌더링 되는 형태입니다.

매번 상태 갱신 시 기존 데이터를 바탕으로 데이터를 덮어씌우거나 추가해주어야 한다는 점,
그 후에 필수적으로 다시 한번 bind를 거쳐야 한다는 점이 합리적이지 못하고

이번 버그와 같이, 데이터가 누락됐을 경우 버그가 발생할 가능성이 높은 점으로 보아
추후에 필수적으로 개선책을 고려해봐야할 것 같습니다. (9/6 오전 스크럼 회의 때 공유드린 부분입니다.)