### PR TITLE
[김지현] 그리드 아이템의 배경 색 수정 및 padding 추가 & pie chart 그리드 기본 height 요소 변경 & 0.2.0 -> 0.2.1 버전 업데이트

### DIFF
--- a/docs/.vuepress/components/VuetifulBoardPlayground.vue
+++ b/docs/.vuepress/components/VuetifulBoardPlayground.vue
@@ -150,7 +150,7 @@
             }
           },
           gridInfo: {
-            x: 6, y: 0, w: 6, h: 15, i: '1', static: false
+            x: 6, y: 0, w: 6, h: 12, i: '1', static: false
           },
         },
         {

--- a/docs/.vuepress/enhanceApp.js
+++ b/docs/.vuepress/enhanceApp.js
@@ -1,7 +1,7 @@
 import UUID from "vue-uuid";
 import '../../src/assets/scss/index.scss';
 
-export default ({ Vue, isServer }) => {
+export default async ({ Vue, isServer }) => {
   Vue.use(UUID);
   if(!isServer){
     await import('../../dist/vuetiful-board.umd.min.js').then(FullpageModalPlugin => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "vuetiful-board",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuetiful-board",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "scripts": {
     "dev": "cd dev && vue-cli-service serve",
     "build": "vue-cli-service build ./src/index.js --target lib",

--- a/src/assets/scss/_theme-colors.scss
+++ b/src/assets/scss/_theme-colors.scss
@@ -5,7 +5,7 @@
   &[data-theme="dark"] {
     --color-app-background: #232323;
     --color-text: #fff;
-    --color-grid-item-background: #17191d;
+    --color-grid-item-background: #34363a;
   }
 }
 

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -106,7 +106,7 @@ export default {
       palette,
       isFirstMount: true,
       darkModeColorOptions: {
-        background: 'rgba(98, 104, 113, 0.35)',
+        background: 'transparent',
         foreColor: '#fff',
       },
       lightModeColorOptions: {
@@ -384,12 +384,18 @@ export default {
 @import '../assets/scss/theme-colors';
 
 .vue-grid-item {
+  padding: 20px;
   touch-action: none;
   background-color: $color-grid-item-background;
 
   &:not(.vue-grid-placeholder) {
     border-radius: 13px;
     box-shadow: rgba(0, 0, 0, 0.08) 0px 4px 10px;
+  }
+
+  @media screen and (max-width: 768px) {
+    // 모바일 환경을 고려한 설정
+    padding: 5px;
   }
 }
 


### PR DESCRIPTION
# 작업 사항

1. 그리드 아이템의 배경 색 변경 (transparent 하게)
2. 파이 차트의 기본 디폴트 그리드 레이아웃 h 요소 변경 (15 -> 12로)
3. 그리드 아이템 내의 기본적인 패딩 값 추가 (모바일 환경을 고려한 미디어 쿼리 적용) 
4. 0.2.0 -> 0.2.1 version update