### PR TITLE
[감하영] HTML root에 [data-theme="xxx"]을 설정하는 로직을 computed로 이동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "vuetiful-board",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.1.7",
+      "version": "0.2.3",
       "license": "MIT",
       "dependencies": {
         "core-js": "^3.6.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vuetiful-board",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "scripts": {
     "dev": "cd dev && vue-cli-service serve",
     "build": "vue-cli-service build ./src/index.js --target lib",

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -269,28 +269,6 @@ export default {
         return item;
       });
     },
-    initFirstMountOptions(selectedTheme) {
-      this.isFirstMount = false;
-
-      return this.datasets.forEach(item => {
-        // TODO: colors와 theme에 (로컬 스토리지 등으로부터) 이전에 설정해두었던 테마, 컬러, 다크 모드의 옵션 값을 담기
-        (item.chartInfo.options.colors = selectedTheme[0].colors),
-          (item.chartInfo.options.theme = {
-            mode: this.isDarkMode(),
-            monochrome: {
-              enabled: false,
-              shadeTo: 'light',
-              shadeIntensity: 0.9,
-            },
-          }),
-          (item.chartInfo.options.chart = this.darkMode
-            ? { ...item.chartInfo.options.chart, ...this.darkModeColorOptions }
-            : {
-                ...this.lightModeColorOptions,
-                ...item.chartInfo.options.chart,
-              });
-      });
-    },
     setDefaultTheme() {
       return this.datasets.forEach(
         item => (item.chartInfo.options.colors = palette[0].colors),
@@ -306,8 +284,7 @@ export default {
       return (this.previousThemeColors = oldColors);
     },
     setMonochromeColor() {
-      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하고,
-      //       테마, 모노크롬, 다크모드 적용 함수에서 옵션 추가후 bindChartInfos를 실행하는 로직이 반복되고 있는 부분 수정 필요
+      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하는 로직 수정 필요
       const monochromeTheme = {
         mode: this.isDarkMode(),
         monochrome: {
@@ -327,12 +304,10 @@ export default {
         return item;
       });
 
-      this.addUniqueId();
-      return this.bindChartInfos();
+      return this.addUniqueId();
     },
     setDarkMode(oldColors) {
-      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하고,
-      //       테마, 모노크롬, 다크모드 적용 함수에서 옵션 추가후 bindChartInfos를 실행하는 로직이 반복되고 있는 부분 수정 필요
+      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하는 로직 수정 필요
       document.documentElement.dataset.theme = this.isDarkMode();
 
       const currentThemeOptions = {
@@ -356,12 +331,10 @@ export default {
         return item;
       });
 
-      this.addUniqueId();
-      this.bindChartInfos();
+      return this.addUniqueId();
     },
     setLightMode(oldColors) {
-      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하고,
-      //       테마, 모노크롬, 다크모드 적용 함수에서 옵션 추가후 bindChartInfos를 실행하는 로직이 반복되고 있는 부분 수정 필요
+      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하는 로직 수정 필요
       document.documentElement.dataset.theme = this.isDarkMode();
 
       const currentThemeOptions = {
@@ -385,8 +358,7 @@ export default {
         return item;
       });
 
-      this.addUniqueId();
-      this.bindChartInfos();
+      return this.addUniqueId();
     },
   },
 };

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -269,11 +269,6 @@ export default {
         return item;
       });
     },
-    setDefaultTheme() {
-      return this.datasets.forEach(
-        item => (item.chartInfo.options.colors = palette[0].colors),
-      );
-    },
     isDarkMode() {
       return this.darkMode ? 'dark' : 'light';
     },

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -278,29 +278,6 @@ export default {
     savePreviousThemeColors(oldColors) {
       return (this.previousThemeColors = oldColors);
     },
-    setMonochromeColor() {
-      // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하는 로직 수정 필요
-      const monochromeTheme = {
-        mode: this.isDarkMode(),
-        monochrome: {
-          enabled: this.isMonochromeMode(),
-          color: this.theme,
-          shadeTo: 'light',
-          shadeIntensity: 0.9,
-        },
-      };
-
-      this.datasets.forEach(item => {
-        item.chartInfo.options.theme = monochromeTheme;
-        item.chartInfo.options.chart = this.darkMode
-          ? { ...item.chartInfo.options.chart, ...this.darkModeColorOptions }
-          : { ...this.lightModeColorOptions, ...item.chartInfo.options.chart };
-
-        return item;
-      });
-
-      return this.addUniqueId();
-    },
     setDarkMode(oldColors) {
       // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하는 로직 수정 필요
       document.documentElement.dataset.theme = this.isDarkMode();

--- a/src/components/VuetifulBoard.vue
+++ b/src/components/VuetifulBoard.vue
@@ -120,6 +120,8 @@ export default {
     chartInfos: function() {
       if (!this.layoutReady) return [];
 
+      document.documentElement.dataset.theme = this.isDarkMode();
+
       if (this.theme.startsWith('#')) {
         const monochromeTheme = {
           mode: this.isDarkMode(),
@@ -280,7 +282,6 @@ export default {
     },
     setDarkMode(oldColors) {
       // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하는 로직 수정 필요
-      document.documentElement.dataset.theme = this.isDarkMode();
 
       const currentThemeOptions = {
         mode: this.isDarkMode(),
@@ -307,7 +308,6 @@ export default {
     },
     setLightMode(oldColors) {
       // TODO: 기존에 존재하는 옵션을 바탕으로 (살린 채로) 테마 관련 옵션을 추가해주어야 하는 로직 수정 필요
-      document.documentElement.dataset.theme = this.isDarkMode();
 
       const currentThemeOptions = {
         mode: this.isDarkMode(),


### PR DESCRIPTION
# 작업 내용

* 0.2.2 ⇨ 0.2.3 업데이트
* HTML root에 [data-theme="xxx"]을 설정하는 로직을 computed로 이동
   * 서비스단에서 설정해둔 dark mode의 default 값을 첫 렌더때 반영시키기 위함. (ex. 서비스단의 초기 렌더 시에는 라이트 모드가 아닌 다크 모드로 설정하고 싶은 상황 등)
* 사용하지 않는 함수 삭제